### PR TITLE
support python2.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.idea*
+.venv*
+
 MANIFEST
 dist/
 build/

--- a/foxpy/fox.py
+++ b/foxpy/fox.py
@@ -1,9 +1,7 @@
 import copy
-import urllib.parse
-
 import requests
-
 from foxpy.utils import extractNifPhrases, insertCharacterAtPosition
+
 
 class Fox(object):
     foxOfficialNERUri = 'http://fox.cs.uni-paderborn.de:4444/call/ner/entities'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='foxpy',
-    version='1.0.0',
+    version='1.0.1',
     author='Ivan Ermilov',
     author_email='earthquakesan@gmail.com',
     packages=['foxpy'],


### PR DESCRIPTION
I removed the url parse as it is not needed and it prevented fox to work with python 2.7